### PR TITLE
chore: change listen call in the example, fastify deprecation warning

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -15,7 +15,7 @@ app.addHook('onClose', (instance, done) => {
 })
 
 async function run(fastifyApp) {
-  await fastifyApp.listen(config.app.port, '0.0.0.0')
+  await fastifyApp.listen({ port: config.app.port, host: '0.0.0.0' })
 }
 
 run(app).catch(err => {


### PR DESCRIPTION
Small change to get rid of the [deprecation warning](https://github.com/fastify/fastify/blob/7ffefaf272e1b0da5c0889e0c7c54ac8203756f2/lib/warnings.js#L22) from fastify when running the example