### PR TITLE
fix: sync the example with the one in the Graphiql plugin

### DIFF
--- a/example/plugins/mercurius.js
+++ b/example/plugins/mercurius.js
@@ -9,11 +9,11 @@ export default fp(
       gateway: {
         services: [
           {
-            name: 'user',
+            name: 'user service',
             url: 'http://localhost:4001/graphql'
           },
           {
-            name: 'post',
+            name: 'post service',
             url: 'http://localhost:4002/graphql'
           }
         ]

--- a/example/plugins/service-1.js
+++ b/example/plugins/service-1.js
@@ -39,7 +39,7 @@ export default fp(
         author: User @requires(fields: "pid title")
       }
 
-      type Query @extends {
+      type Query {
         topPosts(count: Int): [Post]
       }
 

--- a/example/plugins/service-2.js
+++ b/example/plugins/service-2.js
@@ -26,7 +26,7 @@ export default fp(
       hello: String
     }
 
-    type Subscription @extends{ 
+    type Subscription { 
       newUserAdded: User
     }
 


### PR DESCRIPTION
This PR closes #66.

It updates the `example/` with the recent changes done in the `mercurius-federation-info-graphiql-plugin`. Please check [this commit](https://github.com/nearform/mercurius-federation-info-graphiql-plugin/pull/107/commits/eaf99bc16a26dd159b3d8564f619a6793dd2709d):
- It adds the "service" suffix to the two service names 
- it removes the `@extend` from `Query` and `Subscription` definitions
