### PR TITLE
chore: bump husky to version 9

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx --no -- commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "5.1.3",
         "fastify": "^4.9.2",
-        "husky": "^9.0.7",
+        "husky": "^9.0.11",
         "lint-staged": "^15.0.1",
         "mercurius": "^14.0.0",
         "prettier": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "npm run test:unit && npm run test:types",
     "test:unit": "c8 --100 tap --jobs=2 --no-coverage test/*.test.js",
     "test:types": "tsd",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "repository": {
     "type": "git",
@@ -44,7 +44,7 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "5.1.3",
     "fastify": "^4.9.2",
-    "husky": "^9.0.7",
+    "husky": "^9.0.11",
     "lint-staged": "^15.0.1",
     "mercurius": "^14.0.0",
     "prettier": "^3.0.3",


### PR DESCRIPTION
Updated Husky to latest version. Migration guide found [here](https://github.com/typicode/husky/releases/tag/v9.0.1)